### PR TITLE
Fixed icon alignment for icons that sit within buttons.

### DIFF
--- a/src/assets/styles/scss/elements.scss
+++ b/src/assets/styles/scss/elements.scss
@@ -45,3 +45,7 @@ iframe {
 #pause:hover {
     cursor: pointer;
 }
+
+button i {
+    width: 100%;
+}


### PR DESCRIPTION
I have added this small snippet to centre icons within buttons on the Safari web browser. I also ran `gulp code-check` to make sure everything was a-ok 👌🏼
